### PR TITLE
ローカルオブザーバビリティ基盤 (OTel Collector & Grafanaスタック) 構築 (Closes #39)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ AWSオブザーバビリティのパターンを学習するためのeコマー�
 - Terraform
 - LocalStack CLI (`pip install localstack`)
 - LocalStack Desktop（[ダウンロードページ](https://app.localstack.cloud/resources/desktop)からインストール）
+- otel-cli（OpenTelemetry CLI。以下のコマンドでインストール）
+
+    ```bash
+    go install github.com/equinix-labs/otel-cli@latest
+    ```
 
 ## 環境変数の設定
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -65,6 +65,10 @@ tasks:
         silent: true
       - cmd: 'echo "- PhpMyAdmin: http://phpmyadmin.localhost"'
         silent: true
+      - cmd: 'echo "- Mimir: http://mimir.localhost"'
+        silent: true
+      - cmd: 'echo "- Grafana: http://grafana.localhost"'
+        silent: true
       - cmd: 'echo "- Traefikダッシュボード: http://traefik.localhost:8080"'
         silent: true
 

--- a/compose.yml
+++ b/compose.yml
@@ -236,10 +236,97 @@ services:
     networks:
       - ecommerce-network
 
+  otel-collector:
+    image: otel/opentelemetry-collector:latest
+    container_name: otel-collector
+    restart: unless-stopped
+    ports:
+      - "4318:4318"
+    volumes:
+      - ./infra/otel-collector/config.yaml:/etc/otel-collector-config.yaml:ro
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    depends_on:
+      - loki
+      - tempo
+      - mimir
+    networks:
+      - ecommerce-network
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: unless-stopped
+    volumes:
+      - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana_data:/var/lib/grafana
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=false
+    depends_on:
+      - loki
+      - tempo
+      - mimir
+    networks:
+      - ecommerce-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.grafana.rule=Host(`grafana.localhost`)"
+      - "traefik.http.routers.grafana.entrypoints=web"
+      - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+      - "traefik.http.routers.grafana.middlewares=secure-headers@file,cors@file"
+
+  loki:
+    image: grafana/loki:3.4.1
+    container_name: loki
+    restart: unless-stopped
+    volumes:
+      - ./infra/loki/config.yaml:/etc/loki/local-config.yaml:ro
+      - loki_data:/loki
+    command: ["-config.file=/etc/loki/local-config.yaml"]
+    networks:
+      - ecommerce-network
+
+  mimir:
+    image: grafana/mimir:latest
+    container_name: mimir
+    restart: unless-stopped
+    command: ["-config.file=/etc/mimir/config.yaml"]
+    volumes:
+      - ./infra/mimir/config.yaml:/etc/mimir/config.yaml:ro
+      - mimir_data:/mimir
+    networks:
+      - ecommerce-network
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.mimir.rule=Host(`mimir.localhost`)"
+      - "traefik.http.routers.mimir.entrypoints=web"
+      - "traefik.http.services.mimir.loadbalancer.server.port=9009"
+      - "traefik.http.routers.mimir.middlewares=secure-headers@file,cors@file"
+
+  tempo:
+    image: grafana/tempo:latest
+    container_name: tempo
+    restart: unless-stopped
+    command: ["-config.file=/etc/tempo/config.yaml"]
+    volumes:
+      - ./infra/tempo/config.yaml:/etc/tempo/config.yaml:ro
+      - tempo_data:/var/tempo
+    networks:
+      - ecommerce-network
+
 volumes:
   mysql_data:
     driver: local
   localstack_data:
+    driver: local
+  grafana_data:
+    driver: local
+  loki_data:
+    driver: local
+  tempo_data:
+    driver: local
+  mimir_data:
     driver: local
 
 networks:

--- a/infra/grafana/provisioning/datasources/datasources.yaml
+++ b/infra/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,20 @@
+apiVersion: 1
+
+datasources:
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    isDefault: false
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    isDefault: false
+  - name: Mimir
+    type: prometheus
+    access: proxy
+    url: http://mimir:9009/prometheus
+    isDefault: true
+    jsonData:
+      timeInterval: "15s"

--- a/infra/loki/config.yaml
+++ b/infra/loki/config.yaml
@@ -1,0 +1,42 @@
+# Lokiの認証機能を有効化するかどうか（falseで認証なし、デフォルト）
+auth_enabled: false
+
+# サーバー設定: LokiのHTTPリッスンポートを指定
+server:
+  http_listen_port: 3100
+
+# 共通設定: インスタンスアドレスやストレージパスなど
+common:
+  instance_addr: 127.0.0.1 # インスタンスのバインドアドレス
+  path_prefix: /loki # データ保存のパスプレフィックス
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks # チャンクデータの保存先
+      rules_directory: /loki/rules # ルールファイルの保存先
+  replication_factor: 1 # レプリケーション数（単一ノードの場合1）
+  ring:
+    kvstore:
+      store: inmemory # クラスタリング用のKVストア（単一ノードはinmemory）
+
+# スキーマ設定: データの保存方式やインデックスの管理方法
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb # ストレージエンジン（推奨: tsdb）
+      object_store: filesystem # オブジェクトストア（ローカルファイル）
+      schema: v13 # スキーマバージョン
+      index:
+        prefix: index_ # インデックスファイルのプレフィックス
+        period: 24h # インデックスのローテーション周期
+
+# 制限・保持期間などの設定
+limits_config:
+  allow_structured_metadata: true # 構造化メタデータの許可
+  volume_enabled: true # volume APIの有効化
+  retention_period: 672h # ログ保持期間（672h=28日）
+  otlp_config:
+    resource_attributes:
+      attributes_config:
+        - action: index_label
+          attributes:
+            - service.version # OTLP経由で受信したservice.version属性をインデックス化

--- a/infra/mimir/config.yaml
+++ b/infra/mimir/config.yaml
@@ -1,0 +1,58 @@
+# モノリシック設定
+target: all,overrides-exporter
+
+# マルチテナンシー無効
+multitenancy_enabled: false
+
+# 共通ストレージ設定（オプション）
+common:
+  storage:
+    backend: filesystem
+    filesystem:
+      dir: /mimir/storage
+
+# ブロックストレージ設定（メトリクスデータ用）
+blocks_storage:
+  backend: filesystem
+  filesystem:
+    dir: /mimir/blocks
+  tsdb:
+    dir: /mimir/tsdb
+
+# コンパクター設定
+compactor:
+  data_dir: /mimir/compactor
+
+# 分散システムの設定（単一インスタンス用）
+distributor:
+  ring:
+    kvstore:
+      store: memberlist
+
+# インジェスター設定
+ingester:
+  ring:
+    kvstore:
+      store: memberlist
+    replication_factor: 1
+
+# ストアゲートウェイ設定
+store_gateway:
+  sharding_ring:
+    replication_factor: 1
+
+# memberlist設定
+memberlist:
+  node_name: mimir-monolithic
+  bind_port: 7946
+
+# パフォーマンス最適化（オプション）
+limits:
+  max_global_series_per_user: 1000000
+  ingestion_rate: 10000
+
+# サーバー設定
+server:
+  http_listen_port: 9009
+  grpc_listen_port: 9095
+  log_level: info

--- a/infra/otel-collector/config.yaml
+++ b/infra/otel-collector/config.yaml
@@ -1,0 +1,32 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:4317"
+      http:
+        endpoint: "0.0.0.0:4318"
+exporters:
+  debug/stdout:
+    verbosity: detailed
+    sampling_initial: 100
+    sampling_thereafter: 100
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
+  otlphttp/mimir:
+    endpoint: http://mimir:9009/otlp
+  otlp/tempo:
+    endpoint: "tempo:4317"
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [otlphttp/loki]
+    metrics:
+      receivers: [otlp]
+      exporters: [debug/stdout, otlphttp/mimir]
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/tempo]

--- a/infra/scripts/otel-collector/README.md
+++ b/infra/scripts/otel-collector/README.md
@@ -1,0 +1,169 @@
+# Observability Stack Test Scripts
+
+このディレクトリには、OpenTelemetry Collector経由でLoki、Mimir、Tempoに対してログ、メトリクス、トレースを送信するテストスクリプトが含まれています。
+
+## ファイル構成
+
+```text
+infra/scripts/otel-collector/
+├── test_observability.sh      # 単発テスト実行スクリプト
+├── continuous_metrics.sh      # 継続的メトリクス生成スクリプト
+├── templates/                 # JSONテンプレートファイル
+│   ├── logs.json             # ログ送信用JSONテンプレート
+│   ├── metrics.json          # メトリクス送信用JSONテンプレート
+│   └── traces.json           # トレース送信用JSONテンプレート
+└── README.md                 # このファイル
+```
+
+## 前提条件
+
+- OpenTelemetry Collectorが `http://localhost:4318` で起動していること
+- Grafana、Loki、Mimir、Tempoが正常に動作していること
+- `curl` コマンドが利用可能であること
+
+## 使用方法
+
+### 1. 基本動作確認テスト
+
+すべてのコンポーネント（ログ、メトリクス、トレース）の動作を一度に確認：
+
+```bash
+cd /home/yoichi/workspace/aws-observability-ecommerce/infra/scripts/otel-collector
+./test_observability.sh
+```
+
+### 2. デバッグモード実行
+
+生成されたJSONペイロードを表示してデバッグ：
+
+```bash
+./test_observability.sh --debug
+```
+
+### 3. 継続的メトリクス生成
+
+リアルタイムでメトリクスを送信し続ける（デフォルト10秒間隔）：
+
+```bash
+./continuous_metrics.sh
+```
+
+間隔を変更する場合（例：5秒間隔）：
+
+```bash
+./continuous_metrics.sh 5
+```
+
+### 4. ファイル実行権限の設定
+
+スクリプトが実行できない場合：
+
+```bash
+chmod +x test_observability.sh
+chmod +x continuous_metrics.sh
+```
+
+## JSONテンプレートについて
+
+### templates/logs.json
+ログ送信用のOTLP形式JSONテンプレート。以下の変数が置換されます：
+- `{{SERVICE_NAME}}`: サービス名
+- `{{SERVICE_VERSION}}`: サービスバージョン
+- `{{TIMESTAMP}}`: Unix nanosecondタイムスタンプ
+- `{{LOG_MESSAGE}}`: ログメッセージ
+- `{{TRACE_ID}}`: トレースID（ログとトレースの関連付け用）
+
+### templates/metrics.json
+メトリクス送信用のOTLP形式JSONテンプレート。以下の変数が置換されます：
+- `{{METRIC_NAME}}`: メトリクス名
+- `{{METRIC_VALUE}}`: メトリクス値
+- `{{METRIC_DESCRIPTION}}`: メトリクスの説明
+
+### templates/traces.json
+トレース送信用のOTLP形式JSONテンプレート。以下の変数が置換されます：
+- `{{TRACE_ID}}`: トレースID
+- `{{SPAN_ID}}`: スパンID
+- `{{SPAN_NAME}}`: スパン名
+- `{{START_TIME}}`, `{{END_TIME}}`: スパンの開始・終了時刻
+
+## Grafanaでの確認方法
+
+テスト実行後、以下の手順でGrafanaで確認：
+
+1. **Grafanaにアクセス**: http://grafana.localhost
+   - ユーザー名: `admin`
+   - パスワード: `admin`
+
+2. **Exploreタブでデータを確認**:
+
+   **ログ (Loki データソース選択)**:
+   ```
+   {service_name="observability-test"}
+   ```
+
+   **メトリクス (Mimir データソース選択)**:
+   ```
+   test_gauge
+   cpu_usage_percent
+   memory_usage_percent
+   http_requests_total
+   http_response_time_ms
+   ```
+
+   **トレース (Tempo データソース選択)**:
+   - Search画面でTraceIDを検索（スクリプト実行時に表示されます）
+
+## トラブルシューティング
+
+### スクリプトが失敗する場合
+
+1. **コンテナの状態確認**:
+   ```bash
+   docker ps | grep -E "(otel-collector|loki|mimir|tempo|grafana)"
+   ```
+
+2. **OTEL Collectorログ確認**:
+   ```bash
+   docker logs otel-collector
+   ```
+
+3. **各サービスのヘルスチェック**:
+   ```bash
+   curl http://localhost:4318/  # OTEL Collector
+   curl http://localhost:3100/ready  # Loki
+   curl http://localhost:8080/ready  # Mimir
+   curl http://localhost:3200/ready  # Tempo
+   ```
+
+### JSONテンプレートが見つからない場合
+
+テンプレートディレクトリが正しく作成されているか確認：
+```bash
+ls -la /home/yoichi/workspace/aws-observability-ecommerce/infra/scripts/otel-collector/templates/
+```
+
+### Grafanaでデータが表示されない場合
+
+1. データソースの設定確認
+2. 時間範囲の調整（Last 15 minutes推奨）
+3. ログレベルでのフィルタリング確認
+
+## 高度な使用方法
+
+### カスタムJSONテンプレートの作成
+
+新しいテンプレートファイルを作成し、`substitute_template`関数で必要な変数を置換することで、独自のテレメトリーデータを送信できます。
+
+### 異なる環境での実行
+
+スクリプト内の以下の変数を変更することで、異なる環境に対応できます：
+- `OTEL_ENDPOINT`: OTEL Collectorのエンドポイント
+- `SERVICE_NAME`: サービス名
+- `ENVIRONMENT`: 環境名（development/staging/production）
+
+## 参考リンク
+
+- [OpenTelemetry OTLP Specification](https://opentelemetry.io/docs/specs/otlp/)
+- [Grafana Loki Documentation](https://grafana.com/docs/loki/)
+- [Grafana Mimir Documentation](https://grafana.com/docs/mimir/)
+- [Grafana Tempo Documentation](https://grafana.com/docs/tempo/)

--- a/infra/scripts/otel-collector/continuous_metrics.sh
+++ b/infra/scripts/otel-collector/continuous_metrics.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+# Continuous Metrics Generator for Observability Testing
+# Sends metrics to OTEL Collector continuously
+
+# スクリプトのディレクトリを取得
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE_DIR="$SCRIPT_DIR/templates"
+
+# 設定
+OTEL_ENDPOINT="http://localhost:4318"
+SERVICE_NAME="metrics-generator"
+ENVIRONMENT="development"
+INTERVAL=${1:-10}  # デフォルト10秒間隔
+
+echo "🚀 Starting continuous metrics generation..."
+echo "Interval: ${INTERVAL} seconds"
+echo "Service: $SERVICE_NAME"
+echo "Press Ctrl+C to stop"
+echo ""
+
+# JSONテンプレートを変数置換する関数
+substitute_metrics_template() {
+    local template_file="$1"
+    local output_file="$2"
+    local metric_name="$3"
+    local metric_value="$4"
+    local metric_description="$5"
+    local timestamp="$6"
+
+    if [ ! -f "$template_file" ]; then
+        echo "❌ Template file not found: $template_file"
+        return 1
+    fi
+
+    # sedコマンドで置換を実行
+    sed -e "s/{{SERVICE_NAME}}/$SERVICE_NAME/g" \
+        -e "s/{{ENVIRONMENT}}/$ENVIRONMENT/g" \
+        -e "s/{{TIMESTAMP}}/$timestamp/g" \
+        -e "s/{{METER_NAME}}/continuous-meter/g" \
+        -e "s/{{METRIC_NAME}}/$metric_name/g" \
+        -e "s/{{METRIC_DESCRIPTION}}/$metric_description/g" \
+        -e "s/{{METRIC_UNIT}}/1/g" \
+        -e "s/{{METRIC_TYPE}}/continuous_monitoring/g" \
+        -e "s/{{METRIC_VALUE}}/$metric_value/g" \
+        "$template_file" > "$output_file"
+}
+
+# 一時ファイルディレクトリ作成
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR; echo ''; echo '🛑 Continuous metrics generation stopped.'" EXIT
+
+# カウンター初期化
+COUNTER=0
+
+while true; do
+    TIMESTAMP=$(date +%s)000000000
+    COUNTER=$((COUNTER + 1))
+
+    echo -n "📊 Sending metrics batch #$COUNTER - "
+
+    # CPU使用率メトリクス (0-100%)
+    CPU_VALUE=$((RANDOM % 100))
+    CPU_PAYLOAD="$TEMP_DIR/cpu_metrics.json"
+    substitute_metrics_template "$TEMPLATE_DIR/metrics.json" "$CPU_PAYLOAD" \
+        "cpu_usage_percent" "$CPU_VALUE" "Simulated CPU usage percentage" "$TIMESTAMP"
+
+    curl -s -X POST "$OTEL_ENDPOINT/v1/metrics" \
+        -H "Content-Type: application/json" \
+        -d "@$CPU_PAYLOAD" > /dev/null
+
+    # メモリ使用率メトリクス (0-100%)
+    MEMORY_VALUE=$((RANDOM % 100))
+    MEMORY_PAYLOAD="$TEMP_DIR/memory_metrics.json"
+    substitute_metrics_template "$TEMPLATE_DIR/metrics.json" "$MEMORY_PAYLOAD" \
+        "memory_usage_percent" "$MEMORY_VALUE" "Simulated memory usage percentage" "$TIMESTAMP"
+
+    curl -s -X POST "$OTEL_ENDPOINT/v1/metrics" \
+        -H "Content-Type: application/json" \
+        -d "@$MEMORY_PAYLOAD" > /dev/null
+
+    # リクエスト数メトリクス (0-1000)
+    REQUEST_VALUE=$((RANDOM % 1000))
+    REQUEST_PAYLOAD="$TEMP_DIR/request_metrics.json"
+    substitute_metrics_template "$TEMPLATE_DIR/metrics.json" "$REQUEST_PAYLOAD" \
+        "http_requests_total" "$REQUEST_VALUE" "Total HTTP requests" "$TIMESTAMP"
+
+    curl -s -X POST "$OTEL_ENDPOINT/v1/metrics" \
+        -H "Content-Type: application/json" \
+        -d "@$REQUEST_PAYLOAD" > /dev/null
+
+    # レスポンス時間メトリクス (0-2000ms)
+    RESPONSE_TIME=$((RANDOM % 2000))
+    RESPONSE_PAYLOAD="$TEMP_DIR/response_metrics.json"
+    substitute_metrics_template "$TEMPLATE_DIR/metrics.json" "$RESPONSE_PAYLOAD" \
+        "http_response_time_ms" "$RESPONSE_TIME" "HTTP response time in milliseconds" "$TIMESTAMP"
+
+    curl -s -X POST "$OTEL_ENDPOINT/v1/metrics" \
+        -H "Content-Type: application/json" \
+        -d "@$RESPONSE_PAYLOAD" > /dev/null
+
+    echo "CPU: ${CPU_VALUE}%, Memory: ${MEMORY_VALUE}%, Requests: ${REQUEST_VALUE}, Response: ${RESPONSE_TIME}ms ($(date '+%H:%M:%S'))"
+
+    sleep $INTERVAL
+done

--- a/infra/scripts/otel-collector/otel-test.sh
+++ b/infra/scripts/otel-collector/otel-test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# OTel Collectorへのテストデータ送信スクリプト
+# 依存: otel-cli (https://github.com/equinix-labs/otel-cli)
+
+set -e
+
+OTEL_COLLECTOR_ENDPOINT="http://localhost:4318"
+
+# テストログ（spanとして送信、log的な属性を付与）
+otel-cli span --endpoint $OTEL_COLLECTOR_ENDPOINT --protocol http/protobuf \
+  --name "test-log" --service "test-service" --attrs "log.message=test log from otel-cli,env=local"
+
+# テストメトリクス（spanとして送信、metric的な属性を付与）
+otel-cli span --endpoint $OTEL_COLLECTOR_ENDPOINT --protocol http/protobuf \
+  --name "test-metric" --service "test-service" --attrs "metric.name=test_metric,metric.value=1,env=local"
+
+# テストトレース
+otel-cli span --endpoint $OTEL_COLLECTOR_ENDPOINT --protocol http/protobuf \
+  --name "test-span" --service "test-service" --kind client --attrs "env=local"
+
+echo "OTelテストデータ送信完了"

--- a/infra/scripts/otel-collector/templates/logs.json
+++ b/infra/scripts/otel-collector/templates/logs.json
@@ -1,0 +1,44 @@
+{
+  "resourceLogs": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": { "stringValue": "{{SERVICE_NAME}}" }
+          },
+          {
+            "key": "service.version",
+            "value": { "stringValue": "{{SERVICE_VERSION}}" }
+          }
+        ]
+      },
+      "scopeLogs": [
+        {
+          "scope": {
+            "name": "{{LOGGER_NAME}}"
+          },
+          "logRecords": [
+            {
+              "timeUnixNano": "{{TIMESTAMP}}",
+              "severityText": "{{SEVERITY}}",
+              "body": {
+                "stringValue": "{{LOG_MESSAGE}}"
+              },
+              "attributes": [
+                {
+                  "key": "environment",
+                  "value": { "stringValue": "{{ENVIRONMENT}}" }
+                },
+                {
+                  "key": "trace_id",
+                  "value": { "stringValue": "{{TRACE_ID}}" }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/infra/scripts/otel-collector/templates/metrics.json
+++ b/infra/scripts/otel-collector/templates/metrics.json
@@ -1,0 +1,46 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": { "stringValue": "{{SERVICE_NAME}}" }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {
+            "name": "{{METER_NAME}}"
+          },
+          "metrics": [
+            {
+              "name": "{{METRIC_NAME}}",
+              "description": "{{METRIC_DESCRIPTION}}",
+              "unit": "{{METRIC_UNIT}}",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "environment",
+                        "value": { "stringValue": "{{ENVIRONMENT}}" }
+                      },
+                      {
+                        "key": "metric_type",
+                        "value": { "stringValue": "{{METRIC_TYPE}}" }
+                      }
+                    ],
+                    "timeUnixNano": "{{TIMESTAMP}}",
+                    "asInt": "{{METRIC_VALUE}}"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/infra/scripts/otel-collector/templates/traces.json
+++ b/infra/scripts/otel-collector/templates/traces.json
@@ -1,0 +1,49 @@
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": { "stringValue": "{{SERVICE_NAME}}" }
+          },
+          {
+            "key": "service.version",
+            "value": { "stringValue": "{{SERVICE_VERSION}}" }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "{{TRACER_NAME}}"
+          },
+          "spans": [
+            {
+              "traceId": "{{TRACE_ID}}",
+              "spanId": "{{SPAN_ID}}",
+              "name": "{{SPAN_NAME}}",
+              "kind": 1,
+              "startTimeUnixNano": "{{START_TIME}}",
+              "endTimeUnixNano": "{{END_TIME}}",
+              "attributes": [
+                {
+                  "key": "operation.type",
+                  "value": { "stringValue": "{{OPERATION_TYPE}}" }
+                },
+                {
+                  "key": "test.category",
+                  "value": { "stringValue": "{{TEST_CATEGORY}}" }
+                },
+                {
+                  "key": "environment",
+                  "value": { "stringValue": "{{ENVIRONMENT}}" }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/infra/scripts/otel-collector/test_observability.sh
+++ b/infra/scripts/otel-collector/test_observability.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+# Observability Stack Test Script
+# Tests Logs (Loki), Metrics (Mimir), and Traces (Tempo) via OTEL Collector
+
+# スクリプトのディレクトリを取得
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMPLATE_DIR="$SCRIPT_DIR/templates"
+
+# 設定
+OTEL_ENDPOINT="http://localhost:4318"
+SERVICE_NAME="observability-test"
+SERVICE_VERSION="1.0.0"
+ENVIRONMENT="development"
+
+# タイムスタンプとID生成
+TIMESTAMP=$(date +%s)000000000
+TRACE_ID=$(openssl rand -hex 16 | tr '[:lower:]' '[:upper:]')
+SPAN_ID=$(openssl rand -hex 8 | tr '[:lower:]' '[:upper:]')
+END_TIME=$(($TIMESTAMP + 1000000000)) # +1 second
+RANDOM_VALUE=$((RANDOM % 100))
+
+echo "🚀 Testing Observability Stack..."
+echo "Timestamp: $TIMESTAMP"
+echo "Trace ID: $TRACE_ID"
+echo "Span ID: $SPAN_ID"
+echo ""
+
+# JSONテンプレートを変数置換する関数
+substitute_template() {
+    local template_file="$1"
+    local output_file="$2"
+
+    if [ ! -f "$template_file" ]; then
+        echo "❌ Template file not found: $template_file"
+        return 1
+    fi
+
+    # sedコマンドで置換を実行
+    sed -e "s/{{SERVICE_NAME}}/$SERVICE_NAME/g" \
+        -e "s/{{SERVICE_VERSION}}/$SERVICE_VERSION/g" \
+        -e "s/{{ENVIRONMENT}}/$ENVIRONMENT/g" \
+        -e "s/{{TIMESTAMP}}/$TIMESTAMP/g" \
+        -e "s/{{TRACE_ID}}/$TRACE_ID/g" \
+        -e "s/{{SPAN_ID}}/$SPAN_ID/g" \
+        -e "s/{{START_TIME}}/$TIMESTAMP/g" \
+        -e "s/{{END_TIME}}/$END_TIME/g" \
+        -e "s/{{LOGGER_NAME}}/test-logger/g" \
+        -e "s/{{SEVERITY}}/INFO/g" \
+        -e "s|{{LOG_MESSAGE}}|🔍 Test log message - observability stack verification|g" \
+        -e "s/{{METER_NAME}}/test-meter/g" \
+        -e "s/{{METRIC_NAME}}/test_gauge/g" \
+        -e "s/{{METRIC_DESCRIPTION}}/Test gauge metric for observability verification/g" \
+        -e "s/{{METRIC_UNIT}}/1/g" \
+        -e "s/{{METRIC_TYPE}}/observability_verification/g" \
+        -e "s/{{METRIC_VALUE}}/$RANDOM_VALUE/g" \
+        -e "s/{{TRACER_NAME}}/test-tracer/g" \
+        -e "s/{{SPAN_NAME}}/observability-verification/g" \
+        -e "s/{{OPERATION_TYPE}}/test/g" \
+        -e "s/{{TEST_CATEGORY}}/observability/g" \
+        "$template_file" > "$output_file"
+}
+
+# 一時ファイルディレクトリ作成
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf $TEMP_DIR" EXIT
+
+# 1. Test Logs (Loki)
+echo "📝 Testing Logs -> Loki..."
+LOG_PAYLOAD="$TEMP_DIR/logs_payload.json"
+substitute_template "$TEMPLATE_DIR/logs.json" "$LOG_PAYLOAD"
+
+if [ $? -eq 0 ] && [ -f "$LOG_PAYLOAD" ]; then
+    curl -s -X POST "$OTEL_ENDPOINT/v1/logs" \
+        -H "Content-Type: application/json" \
+        -d "@$LOG_PAYLOAD"
+
+    if [ $? -eq 0 ]; then
+        echo "✅ Logs sent successfully"
+    else
+        echo "❌ Failed to send logs"
+    fi
+else
+    echo "❌ Failed to prepare logs payload"
+fi
+echo ""
+
+# 2. Test Metrics (Mimir)
+echo "📊 Testing Metrics -> Mimir..."
+METRICS_PAYLOAD="$TEMP_DIR/metrics_payload.json"
+substitute_template "$TEMPLATE_DIR/metrics.json" "$METRICS_PAYLOAD"
+
+if [ $? -eq 0 ] && [ -f "$METRICS_PAYLOAD" ]; then
+    curl -s -X POST "$OTEL_ENDPOINT/v1/metrics" \
+        -H "Content-Type: application/json" \
+        -d "@$METRICS_PAYLOAD"
+
+    if [ $? -eq 0 ]; then
+        echo "✅ Metrics sent successfully (value: $RANDOM_VALUE)"
+    else
+        echo "❌ Failed to send metrics"
+    fi
+else
+    echo "❌ Failed to prepare metrics payload"
+fi
+echo ""
+
+# 3. Test Traces (Tempo)
+echo "🔍 Testing Traces -> Tempo..."
+TRACES_PAYLOAD="$TEMP_DIR/traces_payload.json"
+substitute_template "$TEMPLATE_DIR/traces.json" "$TRACES_PAYLOAD"
+
+if [ $? -eq 0 ] && [ -f "$TRACES_PAYLOAD" ]; then
+    curl -s -X POST "$OTEL_ENDPOINT/v1/traces" \
+        -H "Content-Type: application/json" \
+        -d "@$TRACES_PAYLOAD"
+
+    if [ $? -eq 0 ]; then
+        echo "✅ Traces sent successfully"
+    else
+        echo "❌ Failed to send traces"
+    fi
+else
+    echo "❌ Failed to prepare traces payload"
+fi
+echo ""
+
+echo "🎉 Observability stack test completed!"
+echo ""
+echo "📋 Next Steps:"
+echo "1. Open Grafana: http://grafana.localhost (admin/admin)"
+echo "2. Check Explore tab to query:"
+echo "   - Logs in Loki: {service_name=\"$SERVICE_NAME\"}"
+echo "   - Metrics in Mimir: test_gauge"
+echo "   - Traces in Tempo: Search for trace ID $TRACE_ID"
+echo ""
+echo "🔗 Direct URLs:"
+echo "   - Grafana: http://grafana.localhost"
+echo "   - Loki: http://localhost:3100"
+echo "   - Mimir: http://localhost:8080"
+echo "   - Tempo: http://localhost:3200"
+echo ""
+
+# デバッグ用：生成されたJSONファイルを表示
+if [ "$1" = "--debug" ]; then
+    echo "🔍 Debug: Generated JSON payloads:"
+    echo ""
+    echo "--- Logs Payload ---"
+    cat "$LOG_PAYLOAD"
+    echo ""
+    echo "--- Metrics Payload ---"
+    cat "$METRICS_PAYLOAD"
+    echo ""
+    echo "--- Traces Payload ---"
+    cat "$TRACES_PAYLOAD"
+    echo ""
+fi

--- a/infra/tempo/config.yaml
+++ b/infra/tempo/config.yaml
@@ -1,0 +1,65 @@
+# HTTPストリーミングを有効化（Grafana Exploreでのリアルタイム表示用）
+stream_over_http_enabled: true
+
+# サーバー設定: TempoのHTTPリッスンポートやログレベル
+server:
+  http_listen_port: 3200 # TempoのWeb UI/API用ポート
+  log_level: info # ログレベル（info/debugなど）
+
+# クエリフロントエンド: 検索やトレース取得のSLO設定
+query_frontend:
+  search:
+    duration_slo: 5s # 検索SLO（秒）
+    throughput_bytes_slo: 1.073741824e+09 # 検索スループットSLO（バイト/秒）
+    metadata_slo:
+      duration_slo: 5s
+      throughput_bytes_slo: 1.073741824e+09
+  trace_by_id:
+    duration_slo: 5s # traceById APIのSLO
+
+# ディストリビュータ: トレース受信設定（OTLP gRPCのみ有効化）
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "tempo:4317" # OTLP gRPC受信用エンドポイント
+
+# インジェスター: トレースのバッチ処理・WALへの書き込み
+ingester:
+  max_block_duration: 5m # ブロックの最大保持時間（デモ用、通常はデフォルト推奨）
+
+# コンパクタ: ブロックの保持期間や圧縮設定
+compactor:
+  compaction:
+    block_retention: 1h # トレース全体の保持期間（デモ用、通常は数日〜数週間）
+
+# メトリクスジェネレータ: トレースからPrometheusメトリクスを生成
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+  traces_storage:
+    path: /var/tempo/generator/traces
+
+# ストレージ設定: ローカルストレージを利用（本番はS3/GCS等推奨）
+storage:
+  trace:
+    backend: local # ストレージバックエンド（local/s3/gcs/azure）
+    wal:
+      path: /var/tempo/wal # WALファイルの保存先
+    local:
+      path: /var/tempo/blocks # トレースブロックの保存先
+
+# オーバーライド設定: デフォルトでメトリクスジェネレータを有効化
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics, local-blocks] # メトリクス生成プロセッサ
+      generate_native_histograms: both # ネイティブヒストグラム生成（classic/native/both）


### PR DESCRIPTION
## 概要

ローカル開発環境でOpenTelemetry Collector＋Grafanaスタック（Loki, Mimir, Tempo）によるオブザーバビリティ基盤を構築し、テスト・運用補助スクリプト一式を追加しました。これにより、AWS本番環境に依存せず、ローカルで分散トレース・メトリクス・ログの一元的な可視化・検証が可能となります。

**関連Issue:** #39

## 変更内容

- docker composeに以下のサービスを追加
  - otel-collector（OpenTelemetry Collector）
  - grafana
  - loki
  - mimir
  - tempo
- 各サービスの設定ファイルをinfra配下に新規作成
- Grafanaのデータソース自動設定（Loki, Mimir, Tempo）
- OTel Collector経由でのログ・メトリクス・トレースの転送パイプライン構築
- テスト・運用補助スクリプト（infra/scripts/otel-collector/）の追加
  - test_observability.sh（全体テスト）
  - continuous_metrics.sh（継続メトリクス送信）
  - OTLP JSONテンプレート
- README.mdにセットアップ・利用手順を追記
- Taskfile.ymlにGrafana/Mimir等のURL表示タスクを追加

## 確認事項

- [x] docker compose upで全サービスが正常起動すること
- [x] infra/scripts/otel-collector/test_observability.sh でログ・メトリクス・トレースが送信できること
- [x] Grafana（http://grafana.localhost）で各データソース（Loki, Mimir, Tempo）が利用可能なこと
- [x] 既存のAWSベースのオブザーバビリティ構成と競合しないこと

動作確認手順:
  1. `docker compose up -d` で環境を起動
  2. `cd infra/scripts/otel-collector && ./test_observability.sh` を実行
  3. GrafanaのExploreタブで各データソースのデータを確認

## スクリーンショット（変更内容がUIに影響する場合）

N/A（UI変更なし）

## 残タスク（もしあれば）

- 本番運用を想定したストレージ・認証・マルチテナンシー等の強化
- Grafanaのサンプルダッシュボード追加

## その他特記事項

- 本構成はローカル開発・学習用途を想定しています。本番利用時はセキュリティや永続化の強化が必要です。
