### PR TITLE
OpenTelemetryリファクタリング: WithSpan/WithSpanValueヘルパー関数導入とインフラ設定最適化

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -117,10 +117,11 @@ tasks:
   clean:backend-api:
     desc: バックエンドのファイルをクリーンアップします
     cmds:
-      - sudo rm -rf backend-api/tmp
-      - sudo rm -rf backend-api/di/wire_gen.go
-      - sudo rm -rf backend-api/internal/shared/infrastructure/models
-      - sudo rm -rf backend-api/internal/shared/presentation/rest/openapi
+      - echo "skip"
+      # - rm -rf backend-api/tmp
+      # - rm -rf backend-api/di/wire_gen.go
+      # - rm -rf backend-api/internal/shared/infrastructure/models
+      # - rm -rf backend-api/internal/shared/presentation/rest/openapi
 
   clean:backend-image-processor:
     desc: バックエンドのファイルをクリーンアップします
@@ -130,14 +131,16 @@ tasks:
   clean:frontend-customer:
     desc: 顧客向けフロントエンドのファイルをクリーンアップします
     cmds:
-      - sudo rm -rf frontend-customer/node_modules
-      - sudo rm -rf frontend-customer/.next
+      - echo "skip"
+      # - sudo rm -rf frontend-customer/node_modules
+      # - sudo rm -rf frontend-customer/.next
 
   clean:frontend-admin:
     desc: 管理者向けフロントエンドのファイルをクリーンアップします
     cmds:
-      - sudo rm -rf frontend-admin/node_modules
-      - sudo rm -rf frontend-admin/.next
+      - echo "skip"
+      # - sudo rm -rf frontend-admin/node_modules
+      # - sudo rm -rf frontend-admin/.next
 
   logs:
     desc: 全コンテナのログを表示します
@@ -301,6 +304,15 @@ tasks:
   migrate:up:
     desc: データベースのマイグレーションを実行
     cmds:
+      - cmd: 'echo "MySQLの起動を確認しています..."'
+        silent: true
+      - |
+        while ! docker compose exec -T mysql mysqladmin ping -h localhost -u root -p"${MYSQL_ROOT_PASSWORD:-rootpassword}" --silent; do
+          echo "MySQLの起動待機中... (5秒後に再試行)"
+          sleep 5
+        done
+      - cmd: 'echo "MySQLが起動しています。マイグレーションを実行します..."'
+        silent: true
       - migrate -path "${MIGRATIONS_PATH}" -database "${MYSQL_DSN}" up
 
   migrate:down:

--- a/backend-api/internal/product/application/usecase/get_product_image.go
+++ b/backend-api/internal/product/application/usecase/get_product_image.go
@@ -24,21 +24,15 @@ func NewGetProductImageUseCase(
 }
 
 // Execute は商品画像取得を実行する
-func (u *GetProductImageUseCase) Execute(ctx context.Context, productID int, size service.SizeType) (res *dto.GetImageResponse, err error) {
-	spanCtx, o := otel.Start(ctx)
-	defer func() {
-		o.End(err)
-	}()
+func (u *GetProductImageUseCase) Execute(ctx context.Context, productID int, size service.SizeType) (*dto.GetImageResponse, error) {
+	return otel.WithSpanValue(ctx, func(spanCtx context.Context, o *otel.Observer) (*dto.GetImageResponse, error) {
+		// 画像データを取得
+		getImageResult, err := u.imageStorage.GetImageData(spanCtx, productID, size)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get image data: %w", err)
+		}
 
-	// 画像データを取得
-	var imageData []byte
-	var contentType string
-
-	imageData, contentType, err = u.imageStorage.GetImageData(spanCtx, productID, size)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get image data: %w", err)
-	}
-
-	// レスポンスを構築
-	return dto.NewGetImageResponse(productID, imageData, contentType), nil
+		// レスポンスを構築
+		return dto.NewGetImageResponse(productID, getImageResult.ImageData, getImageResult.ContentType), nil
+	})
 }

--- a/backend-api/internal/product/domain/service/image_storage.go
+++ b/backend-api/internal/product/domain/service/image_storage.go
@@ -13,11 +13,23 @@ const (
 	Original  = SizeType("original")
 )
 
+// UploadResult はアップロード結果を格納する構造体
+type UploadResult struct {
+	Key  string
+	URLs map[string]string
+}
+
+// GetImageResult は画像取得結果を格納する構造体
+type GetImageResult struct {
+	ImageData   []byte
+	ContentType string
+}
+
 // ImageStorage は商品画像のストレージインターフェース
 type ImageStorage interface {
 	// UploadImage は商品画像をアップロードし、S3のキーとURLマップを返却する
-	UploadImage(ctx context.Context, productID int, imageData []byte) (string, map[string]string, error)
+	UploadImage(ctx context.Context, productID int, imageData []byte) (*UploadResult, error)
 
 	// GetImageData は指定されたサイズの画像データを取得する
-	GetImageData(ctx context.Context, productID int, size SizeType) ([]byte, string, error)
+	GetImageData(ctx context.Context, productID int, size SizeType) (*GetImageResult, error)
 }

--- a/backend-api/internal/product/infrastructure/external/storage/s3_image_storage_impl.go
+++ b/backend-api/internal/product/infrastructure/external/storage/s3_image_storage_impl.go
@@ -32,83 +32,85 @@ func NewS3ImageStorageImpl(s3Client *s3.Client, config configPkg.S3Config) servi
 }
 
 // UploadImage は商品画像をS3にアップロードし、S3キーとURLマップを返却する
-func (s *S3ImageStorageImpl) UploadImage(ctx context.Context, productID int, imageData []byte) (key string, urls map[string]string, err error) {
-	spanCtx, o := otel.Start(ctx,
+func (s *S3ImageStorageImpl) UploadImage(ctx context.Context, productID int, imageData []byte) (*service.UploadResult, error) {
+	return otel.WithSpanValue(ctx, func(spanCtx context.Context, o *otel.Observer) (*service.UploadResult, error) {
+		// content type 判定（先頭512バイトで判断）
+		contentType, ext := utils.Ext(imageData)
+
+		// S3へのアップロード先キーを生成
+		key := fmt.Sprintf("uploads/%d/original.%s", productID, ext)
+
+		// 動的なスパン属性を設定
+		o.SetAttributes(
+			attribute.String("s3.key", key),
+			attribute.String("s3.content_type", contentType),
+		)
+
+		input := &s3.PutObjectInput{
+			Bucket:      aws.String(s.config.BucketName),
+			Key:         aws.String(key),
+			Body:        bytes.NewReader(imageData),
+			ContentType: aws.String(contentType),
+		}
+
+		if _, err := s.s3Client.PutObject(spanCtx, input); err != nil {
+			return nil, fmt.Errorf("failed to upload object %s: %w", key, err)
+		}
+
+		// URLマップを構築
+		bucketName := s.config.BucketName
+		urls := map[string]string{
+			"original":  fmt.Sprintf("http://localhost:4566/%s/%s", bucketName, key),
+			"thumbnail": fmt.Sprintf("http://localhost:4566/%s/resized/thumbnail/original_thumbnail.%s", bucketName, ext),
+			"medium":    fmt.Sprintf("http://localhost:4566/%s/resized/medium/original_medium.%s", bucketName, ext),
+			"large":     fmt.Sprintf("http://localhost:4566/%s/resized/large/original_large.%s", bucketName, ext),
+		}
+
+		return &service.UploadResult{Key: key, URLs: urls}, nil
+	},
 		attribute.String("s3.operation", "upload"),
 		attribute.String("s3.bucket", s.config.BucketName),
-		attribute.String("s3.key", key),
 	)
-	defer func() {
-		o.End(err)
-	}()
-
-	// content type 判定（先頭512バイトで判断）
-	contentType, ext := utils.Ext(imageData)
-
-	// S3へのアップロード先キーを生成
-	key = fmt.Sprintf("uploads/%d/original.%s", productID, ext)
-
-	o.SetAttributes(attribute.String("s3.content_type", contentType))
-
-	input := &s3.PutObjectInput{
-		Bucket:      aws.String(s.config.BucketName),
-		Key:         aws.String(key),
-		Body:        bytes.NewReader(imageData),
-		ContentType: aws.String(contentType),
-	}
-
-	if _, err = s.s3Client.PutObject(spanCtx, input); err != nil {
-		return "", nil, fmt.Errorf("failed to upload object %s: %w", key, err)
-	}
-
-	// URLマップを構築
-	bucketName := s.config.BucketName
-	urls = map[string]string{
-		"original":  fmt.Sprintf("http://localhost:4566/%s/%s", bucketName, key),
-		"thumbnail": fmt.Sprintf("http://localhost:4566/%s/resized/thumbnail/original_thumbnail.%s", bucketName, ext),
-		"medium":    fmt.Sprintf("http://localhost:4566/%s/resized/medium/original_medium.%s", bucketName, ext),
-		"large":     fmt.Sprintf("http://localhost:4566/%s/resized/large/original_large.%s", bucketName, ext),
-	}
-
-	return key, urls, nil
 }
 
 // GetImageData は指定されたサイズの画像データを取得する
-func (s *S3ImageStorageImpl) GetImageData(ctx context.Context, productID int, size service.SizeType) (imageData []byte, contentType string, err error) {
-	spanCtx, o := otel.Start(ctx,
+func (s *S3ImageStorageImpl) GetImageData(ctx context.Context, productID int, size service.SizeType) (*service.GetImageResult, error) {
+	return otel.WithSpanValue(ctx, func(spanCtx context.Context, o *otel.Observer) (*service.GetImageResult, error) {
+		// サイズのバリデーション
+		if size != "thumbnail" && size != "medium" && size != "large" && size != "original" {
+			return nil, errors.Newf("invalid image size: %s", size)
+		}
+		// S3のキーを構築
+		key := fmt.Sprintf("resized/%d/original_%s.png", productID, size)
+
+		// 動的なスパン属性を設定
+		o.SetAttributes(attribute.String("s3.key", key))
+
+		input := &s3.GetObjectInput{
+			Bucket: aws.String(s.config.BucketName),
+			Key:    aws.String(key),
+		}
+		result, err := s.s3Client.GetObject(spanCtx, input)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get object %s: %w", key, err)
+		}
+		reader := result.Body
+		defer func(reader io.ReadCloser) {
+			if closeErr := reader.Close(); closeErr != nil {
+				err = errors.Wrapf(closeErr, "original error: %v, failed to close image data", err)
+				return
+			}
+		}(reader)
+		// 画像データを読み込む
+		imageData, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to read image data")
+		}
+		// Content-Typeを拡張子から判断
+		contentType := utils.ContentType(imageData)
+		return &service.GetImageResult{ImageData: imageData, ContentType: contentType}, nil
+	},
 		attribute.String("s3.operation", "get"),
 		attribute.String("s3.bucket", s.config.BucketName),
 	)
-	defer func() {
-		o.End(err)
-	}()
-	// サイズのバリデーション
-	if size != "thumbnail" && size != "medium" && size != "large" && size != "original" {
-		return nil, "", errors.Newf("invalid image size: %s", size)
-	}
-	// S3のキーを構築
-	key := fmt.Sprintf("resized/%d/original_%s.png", productID, size)
-	o.SetAttributes(attribute.String("s3.key", key))
-	input := &s3.GetObjectInput{
-		Bucket: aws.String(s.config.BucketName),
-		Key:    aws.String(key),
-	}
-	result, err := s.s3Client.GetObject(spanCtx, input)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to get object %s: %w", key, err)
-	}
-	reader := result.Body
-	defer func(reader io.ReadCloser) {
-		if closeErr := reader.Close(); closeErr != nil {
-			err = errors.Wrapf(closeErr, "original error: %v, failed to close image data", err)
-			return
-		}
-	}(reader)
-	// 画像データを読み込む
-	if imageData, err = io.ReadAll(reader); err != nil {
-		return nil, "", errors.Wrap(err, "failed to read image data")
-	}
-	// Content-Typeを拡張子から判断
-	contentType = utils.ContentType(imageData)
-	return imageData, contentType, nil
 }

--- a/backend-api/internal/query/rest/handler/product_catalog_handler.go
+++ b/backend-api/internal/query/rest/handler/product_catalog_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -8,6 +9,7 @@ import (
 
 	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/internal/query/rest/mapper"
 	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/internal/query/rest/reader"
+	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/pkg/otel"
 
 	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/internal/shared/presentation/rest/openapi"
 )
@@ -28,58 +30,62 @@ func NewProductCatalogHandler() *ProductCatalogHandler {
 
 // ListProducts は商品一覧を取得する（OpenAPI仕様に準拠）
 func (h *ProductCatalogHandler) ListProducts(ctx echo.Context, params openapi.ListProductsParams) error {
-	// パラメータ変換
-	readerParams := &reader.ProductListParams{}
+	return otel.WithSpan(ctx.Request().Context(), func(spanCtx context.Context, o *otel.Observer) error {
+		// パラメータ変換
+		readerParams := &reader.ProductListParams{}
 
-	if params.Page != nil {
-		readerParams.Page = *params.Page
-	}
-	if params.PageSize != nil {
-		readerParams.PageSize = *params.PageSize
-	}
-	if params.CategoryId != nil {
-		categoryID := *params.CategoryId
-		readerParams.CategoryID = &categoryID
-	}
-	if params.Keyword != nil && *params.Keyword != "" {
-		readerParams.Keyword = params.Keyword
-	}
+		if params.Page != nil {
+			readerParams.Page = *params.Page
+		}
+		if params.PageSize != nil {
+			readerParams.PageSize = *params.PageSize
+		}
+		if params.CategoryId != nil {
+			categoryID := *params.CategoryId
+			readerParams.CategoryID = &categoryID
+		}
+		if params.Keyword != nil && *params.Keyword != "" {
+			readerParams.Keyword = params.Keyword
+		}
 
-	// データ取得
-	products, total, err := h.reader.FindProductsWithDetails(ctx.Request().Context(), readerParams)
-	if err != nil {
-		return fmt.Errorf("failed to fetch products by category: %s", err)
-	}
+		// データ取得
+		productsWithTotal, err := h.reader.FindProductsWithDetails(spanCtx, readerParams)
+		if err != nil {
+			return fmt.Errorf("failed to fetch products by category: %s", err)
+		}
 
-	// レスポンス変換
-	response := h.mapper.ToProductListResponse(products, total, readerParams.Page, readerParams.PageSize)
+		// レスポンス変換
+		response := h.mapper.ToProductListResponse(productsWithTotal.Products, productsWithTotal.Total, readerParams.Page, readerParams.PageSize)
 
-	return ctx.JSON(http.StatusOK, response)
+		return ctx.JSON(http.StatusOK, response)
+	})
 }
 
 // ListProductsByCategory は指定されたカテゴリーの商品一覧を取得する
 func (h *ProductCatalogHandler) ListProductsByCategory(ctx echo.Context, id openapi.CategoryIdPathParam, params openapi.ListProductsByCategoryParams) error {
-	// パラメータ変換
-	readerParams := &reader.ProductListParams{}
+	return otel.WithSpan(ctx.Request().Context(), func(spanCtx context.Context, o *otel.Observer) error {
+		// パラメータ変換
+		readerParams := &reader.ProductListParams{}
 
-	if params.Page != nil {
-		readerParams.Page = *params.Page
-	}
-	if params.PageSize != nil {
-		readerParams.PageSize = *params.PageSize
-	}
+		if params.Page != nil {
+			readerParams.Page = *params.Page
+		}
+		if params.PageSize != nil {
+			readerParams.PageSize = *params.PageSize
+		}
 
-	categoryID := id
-	readerParams.CategoryID = &categoryID
+		categoryID := id
+		readerParams.CategoryID = &categoryID
 
-	// データ取得
-	products, total, err := h.reader.FindProductsWithDetails(ctx.Request().Context(), readerParams)
-	if err != nil {
-		return fmt.Errorf("failed to fetch products by category: %s", err)
-	}
+		// データ取得
+		productsWithTotal, err := h.reader.FindProductsWithDetails(spanCtx, readerParams)
+		if err != nil {
+			return fmt.Errorf("failed to fetch products by category: %s", err)
+		}
 
-	// レスポンス変換
-	response := h.mapper.ToProductListResponse(products, total, readerParams.Page, readerParams.PageSize)
+		// レスポンス変換
+		response := h.mapper.ToProductListResponse(productsWithTotal.Products, productsWithTotal.Total, readerParams.Page, readerParams.PageSize)
 
-	return ctx.JSON(http.StatusOK, response)
+		return ctx.JSON(http.StatusOK, response)
+	})
 }

--- a/backend-api/internal/query/rest/handler/product_detail_handler.go
+++ b/backend-api/internal/query/rest/handler/product_detail_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/internal/shared/presentation/rest/openapi"
+	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/pkg/otel"
 
 	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/internal/query/rest/mapper"
 	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/internal/query/rest/reader"
@@ -30,24 +32,26 @@ func NewProductDetailHandler() *ProductDetailHandler {
 
 // GetProductById は指定されたIDの商品を取得する
 func (h *ProductDetailHandler) GetProductById(ctx echo.Context, id openapi.ProductIdParam) error {
-	// IDの整合性チェック
-	if id <= 0 {
-		return fmt.Errorf("id must be a positive integer")
-	}
-
-	// 商品詳細取得
-	product, err := h.reader.FindProductByID(ctx.Request().Context(), id)
-	if err != nil {
-		// 商品が見つからない場合と内部エラーを区別
-		if errors.Is(err, sql.ErrNoRows) {
-			return fmt.Errorf("product not found: %w", err)
+	return otel.WithSpan(ctx.Request().Context(), func(spanCtx context.Context, o *otel.Observer) error {
+		// IDの整合性チェック
+		if id <= 0 {
+			return fmt.Errorf("id must be a positive integer")
 		}
 
-		return fmt.Errorf("failed to fetch product by id: %w", err)
-	}
+		// 商品詳細取得
+		product, err := h.reader.FindProductByID(spanCtx, id)
+		if err != nil {
+			// 商品が見つからない場合と内部エラーを区別
+			if errors.Is(err, sql.ErrNoRows) {
+				return fmt.Errorf("product not found: %w", err)
+			}
 
-	// レスポンス変換
-	response := h.mapper.ToProductResponse(product)
+			return fmt.Errorf("failed to fetch product by id: %w", err)
+		}
 
-	return ctx.JSON(http.StatusOK, response)
+		// レスポンス変換
+		response := h.mapper.ToProductResponse(product)
+
+		return ctx.JSON(http.StatusOK, response)
+	})
 }

--- a/backend-api/internal/query/rest/reader/category_list_reader.go
+++ b/backend-api/internal/query/rest/reader/category_list_reader.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/internal/shared/infrastructure/database"
 	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/internal/shared/infrastructure/models"
+	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/pkg/otel"
 )
 
 // CategoryListReader はカテゴリー一覧データの読み取りを担当
@@ -26,38 +27,40 @@ type CategoryWithCount struct {
 
 // FindCategoriesWithProductCount はカテゴリー一覧を商品数付きで取得
 func (r *CategoryListReader) FindCategoriesWithProductCount(ctx context.Context) ([]*CategoryWithCount, error) {
-	db := database.GetDB()
+	return otel.WithSpanValue(ctx, func(spanCtx context.Context, o *otel.Observer) ([]*CategoryWithCount, error) {
+		db := database.GetDB()
 
-	// カテゴリー一覧を取得
-	query := models.Categories.Query(
-		sm.OrderBy(models.CategoryColumns.Name).Asc(),
-	)
-	categories, err := query.All(ctx, db)
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to fetch categories: %w", err)
-	}
-
-	// 各カテゴリーの商品数を取得
-	result := make([]*CategoryWithCount, 0, len(categories))
-
-	for _, category := range categories {
-		var count int64
-
-		// 商品数をカウント
-		countQuery := models.Products.Query(
-			models.SelectWhere.Products.CategoryID.EQ(category.ID),
+		// カテゴリー一覧を取得
+		query := models.Categories.Query(
+			sm.OrderBy(models.CategoryColumns.Name).Asc(),
 		)
-		count, err := countQuery.Count(ctx, db)
+		categories, err := query.All(spanCtx, db)
+
 		if err != nil {
-			return nil, fmt.Errorf("failed to count products for category %d: %w", category.ID, err)
+			return nil, fmt.Errorf("failed to fetch categories: %w", err)
 		}
 
-		result = append(result, &CategoryWithCount{
-			Category:     category,
-			ProductCount: count,
-		})
-	}
+		// 各カテゴリーの商品数を取得
+		result := make([]*CategoryWithCount, 0, len(categories))
 
-	return result, nil
+		for _, category := range categories {
+			var count int64
+
+			// 商品数をカウント
+			countQuery := models.Products.Query(
+				models.SelectWhere.Products.CategoryID.EQ(category.ID),
+			)
+			count, err := countQuery.Count(spanCtx, db)
+			if err != nil {
+				return nil, fmt.Errorf("failed to count products for category %d: %w", category.ID, err)
+			}
+
+			result = append(result, &CategoryWithCount{
+				Category:     category,
+				ProductCount: count,
+			})
+		}
+
+		return result, nil
+	})
 }

--- a/backend-api/internal/query/rest/reader/product_detail_reader.go
+++ b/backend-api/internal/query/rest/reader/product_detail_reader.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/internal/shared/infrastructure/database"
 	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/internal/shared/infrastructure/models"
+	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/pkg/otel"
 	"github.com/y-nosuke/aws-observability-ecommerce/backend-api/pkg/utils"
 )
 
@@ -21,31 +22,33 @@ func NewProductDetailReader() *ProductDetailReader {
 
 // FindProductByID は指定されたIDの商品を詳細情報付きで取得
 func (r *ProductDetailReader) FindProductByID(ctx context.Context, id int) (*models.Product, error) {
-	db := database.GetDB()
+	return otel.WithSpanValue(ctx, func(spanCtx context.Context, o *otel.Observer) (*models.Product, error) {
+		db := database.GetDB()
 
-	// 安全なintからint32への変換（共通化した関数を使用）
-	productID, err := utils.SafeIntToInt32(id)
-	if err != nil {
-		return nil, fmt.Errorf("product ID conversion error: %w", err)
-	}
-
-	// Bobでクエリを構築
-	query := models.Products.Query(
-		models.SelectWhere.Products.ID.EQ(productID),
-		// カテゴリーを事前読み込み（LEFT JOIN）
-		models.Preload.Product.Category(),
-		// 在庫情報を後続読み込み（別クエリ）
-		models.SelectThenLoad.Product.Inventories(),
-	)
-
-	// 商品詳細を取得
-	product, err := query.One(ctx, db)
-	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return nil, fmt.Errorf("product not found: %d", id)
+		// 安全なintからint32への変換（共通化した関数を使用）
+		productID, err := utils.SafeIntToInt32(id)
+		if err != nil {
+			return nil, fmt.Errorf("product ID conversion error: %w", err)
 		}
-		return nil, fmt.Errorf("failed to fetch product: %w", err)
-	}
 
-	return product, nil
+		// Bobでクエリを構築
+		query := models.Products.Query(
+			models.SelectWhere.Products.ID.EQ(productID),
+			// カテゴリーを事前読み込み（LEFT JOIN）
+			models.Preload.Product.Category(),
+			// 在庫情報を後続読み込み（別クエリ）
+			models.SelectThenLoad.Product.Inventories(),
+		)
+
+		// 商品詳細を取得
+		product, err := query.One(spanCtx, db)
+		if err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return nil, fmt.Errorf("product not found: %d", id)
+			}
+			return nil, fmt.Errorf("failed to fetch product: %w", err)
+		}
+
+		return product, nil
+	})
 }

--- a/backend-api/pkg/otel/logger.go
+++ b/backend-api/pkg/otel/logger.go
@@ -49,6 +49,7 @@ func NewLogger(provider *sdklog.LoggerProvider, cfg config.LoggingConfig) *slog.
 		handler = slog.NewTextHandler(os.Stdout, opts)
 	}
 	handler = NewTraceHandler(handler)
+
 	// OpenTelemetry ブリッジを使用
 	if cfg.EnableOTel {
 		handler = slogmulti.Fanout(

--- a/backend-api/pkg/otel/span_helper.go
+++ b/backend-api/pkg/otel/span_helper.go
@@ -8,7 +8,7 @@ import (
 
 // WithSpan は関数を実行する際に自動的にスパンを開始・終了します
 func WithSpan(ctx context.Context, fn func(context.Context, *Observer) error, attrs ...attribute.KeyValue) error {
-	spanCtx, o := Start(ctx, attrs...)
+	spanCtx, o := Start(ctx, WithSkip(2), WithAttributes(attrs...))
 	err := fn(spanCtx, o)
 	o.End(err)
 	return err
@@ -16,7 +16,7 @@ func WithSpan(ctx context.Context, fn func(context.Context, *Observer) error, at
 
 // WithSpanValue は戻り値を持つ関数版です
 func WithSpanValue[T any](ctx context.Context, fn func(context.Context, *Observer) (T, error), attrs ...attribute.KeyValue) (T, error) {
-	spanCtx, o := Start(ctx, attrs...)
+	spanCtx, o := Start(ctx, WithSkip(2), WithAttributes(attrs...))
 	result, err := fn(spanCtx, o)
 	o.End(err)
 	return result, err

--- a/backend-api/pkg/otel/span_helper.go
+++ b/backend-api/pkg/otel/span_helper.go
@@ -1,0 +1,23 @@
+package otel
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+)
+
+// WithSpan は関数を実行する際に自動的にスパンを開始・終了します
+func WithSpan(ctx context.Context, fn func(context.Context, *Observer) error, attrs ...attribute.KeyValue) error {
+	spanCtx, o := Start(ctx, attrs...)
+	err := fn(spanCtx, o)
+	o.End(err)
+	return err
+}
+
+// WithSpanValue は戻り値を持つ関数版です
+func WithSpanValue[T any](ctx context.Context, fn func(context.Context, *Observer) (T, error), attrs ...attribute.KeyValue) (T, error) {
+	spanCtx, o := Start(ctx, attrs...)
+	result, err := fn(spanCtx, o)
+	o.End(err)
+	return result, err
+}

--- a/compose.yml
+++ b/compose.yml
@@ -46,11 +46,6 @@ services:
       - AWS_ENDPOINT=http://localstack:4566
       - AWS_ACCESS_KEY_ID=test
       - AWS_SECRET_ACCESS_KEY=test
-      # OpenTelemetry設定
-      - OTEL_EXPORTER_OTLP_ENDPOINT=otel-collector:4317
-      - OTEL_SERVICE_NAME=aws-observability-ecommerce
-      - OTEL_SERVICE_VERSION=1.0.0
-      - OTEL_RESOURCE_ATTRIBUTES=service.name=aws-observability-ecommerce,service.version=1.0.0,deployment.environment=development
     volumes:
       - ./backend-api:/app # ホットリロード用
     depends_on:
@@ -294,34 +289,6 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.prometheus.rule=Host(`prometheus.localhost`)"
       - "traefik.http.routers.prometheus.entrypoints=web"
-    networks:
-      - ecommerce-network
-    deploy:
-      resources:
-        limits:
-          memory: 256M
-
-  alloy:
-    image: grafana/alloy:latest
-    container_name: alloy
-    hostname: alloy.localhost
-    depends_on:
-      - loki
-    volumes:
-      - ./infra/alloy/config.alloy:/etc/alloy/config.alloy
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-    command:
-      [
-        "run",
-        "--server.http.listen-addr=0.0.0.0:12345",
-        "--storage.path=/var/lib/alloy/data",
-        "/etc/alloy/config.alloy",
-      ]
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.routers.alloy.rule=Host(`alloy.localhost`)"
-      - "traefik.http.routers.alloy.entrypoints=web"
-      - "traefik.http.services.alloy.loadbalancer.server.port=12345"
     networks:
       - ecommerce-network
     deploy:

--- a/compose.yml
+++ b/compose.yml
@@ -56,8 +56,8 @@ services:
     depends_on:
       mysql:
         condition: service_healthy
-      # otel-collector:
-      #   condition: service_healthy
+      otel-collector:
+        condition: service_started
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/health"]
       interval: 10s
@@ -254,67 +254,83 @@ services:
       #   condition: service_healthy
     networks:
       - ecommerce-network
-    # healthcheck:
-    #   test: ["CMD", "curl", "-f", "http://localhost:13133/"]
-    #   interval: 10s
-    #   timeout: 5s
-    #   retries: 3
-    #   start_period: 10s
-    # deploy:
-    #   resources:
-    #     limits:
-    #       memory: 256M
-
-  grafana:
-    image: grafana/grafana:latest
-    container_name: grafana
-    restart: unless-stopped
-    volumes:
-      - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
-      - grafana_data:/var/lib/grafana
-    environment:
-      - GF_AUTH_ANONYMOUS_ENABLED=true
-      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-      - GF_AUTH_DISABLE_LOGIN_FORM=false
-    depends_on:
-      - loki
-      - tempo
-      - mimir
-      # loki:
-      #   condition: service_healthy
-      # mimir:
-      #   condition: service_healthy
-      # tempo:
-      #   condition: service_healthy
-    networks:
-      - ecommerce-network
-    # healthcheck:
-    #   test:
-    #     [
-    #       "CMD",
-    #       "wget",
-    #       "--no-verbose",
-    #       "--tries=1",
-    #       "--spider",
-    #       "http://localhost:3000/api/health",
-    #     ]
-    #   interval: 10s
-    #   timeout: 5s
-    #   retries: 3
-    #   start_period: 20s
+    healthcheck:
+      # curlコマンドがインストールされていないので無効化
+      disable: true
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.grafana.rule=Host(`grafana.localhost`)"
-      - "traefik.http.routers.grafana.entrypoints=web"
-      - "traefik.http.services.grafana.loadbalancer.server.port=3000"
-      - "traefik.http.routers.grafana.middlewares=secure-headers@file,cors@file"
-    # deploy:
-    #   resources:
-    #     limits:
-    #       memory: 256M
+      # health_check endpoint
+      - "traefik.http.routers.otel-health.rule=Host(`otel-health.localhost`)"
+      - "traefik.http.routers.otel-health.entrypoints=web"
+      - "traefik.http.services.otel-health.loadbalancer.server.port=13133"
+      - "traefik.http.routers.otel-health.middlewares=secure-headers@file,cors@file"
+      # pprof endpoint
+      - "traefik.http.routers.otel-pprof.rule=Host(`otel-pprof.localhost`)"
+      - "traefik.http.routers.otel-pprof.entrypoints=web"
+      - "traefik.http.services.otel-pprof.loadbalancer.server.port=1777"
+      - "traefik.http.routers.otel-pprof.middlewares=secure-headers@file,cors@file"
+      # zpages endpoint
+      - "traefik.http.routers.otel-zpages.rule=Host(`otel-zpages.localhost`)"
+      - "traefik.http.routers.otel-zpages.entrypoints=web"
+      - "traefik.http.services.otel-zpages.loadbalancer.server.port=55679"
+      - "traefik.http.routers.otel-zpages.middlewares=secure-headers@file,cors@file"
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    hostname: prometheus.localhost
+    command:
+      - --config.file=/etc/prometheus.yaml
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
+      - --enable-feature=native-histograms
+    volumes:
+      - ./infra/prometheus/config.yaml:/etc/prometheus.yaml
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.prometheus.rule=Host(`prometheus.localhost`)"
+      - "traefik.http.routers.prometheus.entrypoints=web"
+    networks:
+      - ecommerce-network
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    hostname: alloy.localhost
+    depends_on:
+      - loki
+    volumes:
+      - ./infra/alloy/config.alloy:/etc/alloy/config.alloy
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    command:
+      [
+        "run",
+        "--server.http.listen-addr=0.0.0.0:12345",
+        "--storage.path=/var/lib/alloy/data",
+        "/etc/alloy/config.alloy",
+      ]
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.alloy.rule=Host(`alloy.localhost`)"
+      - "traefik.http.routers.alloy.entrypoints=web"
+      - "traefik.http.services.alloy.loadbalancer.server.port=12345"
+    networks:
+      - ecommerce-network
+    deploy:
+      resources:
+        limits:
+          memory: 256M
 
   loki:
-    image: grafana/loki:3.4.1
+    image: grafana/loki:3.4.4
     container_name: loki
     restart: unless-stopped
     volumes:
@@ -337,10 +353,10 @@ services:
     #   start_period: 15s
     networks:
       - ecommerce-network
-    # deploy:
-    #   resources:
-    #     limits:
-    #       memory: 512M
+    deploy:
+      resources:
+        limits:
+          memory: 512M
 
   mimir:
     image: grafana/mimir:latest
@@ -376,10 +392,10 @@ services:
       - "traefik.http.routers.mimir.entrypoints=web"
       - "traefik.http.services.mimir.loadbalancer.server.port=9009"
       - "traefik.http.routers.mimir.middlewares=secure-headers@file,cors@file"
-    # deploy:
-    #   resources:
-    #     limits:
-    #       memory: 1G
+    deploy:
+      resources:
+        limits:
+          memory: 1G
 
   tempo:
     image: grafana/tempo:latest
@@ -405,6 +421,61 @@ services:
     #   timeout: 5s
     #   retries: 3
     #   start_period: 15s
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    restart: unless-stopped
+    volumes:
+      - ./infra/grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana_data:/var/lib/grafana
+    environment:
+      - GF_PATHS_PROVISIONING=/etc/grafana/provisioning
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=false
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor traceQLStreaming metricsSummary
+    depends_on:
+      - prometheus
+      - loki
+      - mimir
+      - tempo
+      # loki:
+      #   condition: service_healthy
+      # mimir:
+      #   condition: service_healthy
+      # tempo:
+      #   condition: service_healthy
+    networks:
+      - ecommerce-network
+    # healthcheck:
+    #   test:
+    #     [
+    #       "CMD",
+    #       "wget",
+    #       "--no-verbose",
+    #       "--tries=1",
+    #       "--spider",
+    #       "http://localhost:3000/api/health",
+    #     ]
+    #   interval: 10s
+    #   timeout: 5s
+    #   retries: 3
+    #   start_period: 20s
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.grafana.rule=Host(`grafana.localhost`)"
+      - "traefik.http.routers.grafana.entrypoints=web"
+      - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+      - "traefik.http.routers.grafana.middlewares=secure-headers@file,cors@file"
+    deploy:
+      resources:
+        limits:
+          memory: 256M
 
 volumes:
   mysql_data:

--- a/infra/alloy/config.alloy
+++ b/infra/alloy/config.alloy
@@ -1,0 +1,30 @@
+// Discover Docker containers and extract metadata.
+discovery.docker "linux" {
+  host = "unix:///var/run/docker.sock"
+}
+
+// Define a relabeling rule to create a service name from the container name.
+discovery.relabel "logs_integrations_docker" {
+    targets = []
+
+    rule {
+        source_labels = ["__meta_docker_container_name"]
+        regex = "/(.*)"
+        target_label = "service_name"
+    }
+}
+
+// Configure a loki.source.docker component to collect logs from Docker containers.
+loki.source.docker "default" {
+  host       = "unix:///var/run/docker.sock"
+  targets    = discovery.docker.linux.targets
+  labels     = {"platform" = "docker"}
+  relabel_rules = discovery.relabel.logs_integrations_docker.rules
+  forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}

--- a/infra/grafana/provisioning/datasources/datasources.yaml
+++ b/infra/grafana/provisioning/datasources/datasources.yaml
@@ -3,11 +3,22 @@ apiVersion: 1
 datasources:
   - name: Loki
     type: loki
+    uid: loki
     access: proxy
+    orgId: 1
     url: http://loki:3100
-    uid: loki # 追加: ダッシュボードで参照するUID
+    basicAuth: false
     isDefault: true
+    version: 1
     editable: true
+    jsonData:
+      derivedFields:
+        - datasourceName: Tempo
+          datasourceUid: tempo
+          matcherRegex: trace_id
+          matcherType: label
+          name: traceID
+          url: "$${__value.raw}"
 
   - name: Mimir
     type: prometheus
@@ -23,8 +34,41 @@ datasources:
 
   - name: Tempo
     type: tempo
-    access: proxy
-    url: http://tempo:3200
     uid: tempo
+    access: proxy
+    orgId: 1
+    url: http://tempo:3200
+    basicAuth: false
     isDefault: false
+    version: 1
     editable: true
+    apiVersion: 1
+    jsonData:
+      httpMethod: GET
+      serviceMap:
+        datasourceUid: prometheus
+      lokiSearch:
+        datasourceUid: loki
+      tracesToLogsV2:
+        datasourceUid: loki
+        spanStartTimeShift: -1h
+        spanEndTimeShift: 1h
+        tags:
+          [{ key: "container" }, { key: "service.name", value: "service_name" }]
+        filterByTraceID: false
+        filterBySpanID: false
+        customQuery: true
+        query: '{$${__tags}} | trace_id="$${__span.traceId}"'
+
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: true
+    jsonData:
+      httpMethod: GET

--- a/infra/loki/config.yaml
+++ b/infra/loki/config.yaml
@@ -6,6 +6,7 @@ server:
   log_level: info
 
 common:
+  instance_addr: 127.0.0.1
   path_prefix: /loki
   storage:
     filesystem:
@@ -13,7 +14,6 @@ common:
       rules_directory: /loki/rules
   replication_factor: 1
   ring:
-    instance_addr: 127.0.0.1
     kvstore:
       store: inmemory
 

--- a/infra/loki/config.yaml
+++ b/infra/loki/config.yaml
@@ -59,14 +59,6 @@ limits_config:
             - service.version
             - deployment.environment
             - environment
-        # トレース情報を構造化メタデータとして保存
-        - action: structured_metadata
-          attributes:
-            - trace_id
-            - span_id
-        # 全ての残りの属性を構造化メタデータとして保存
-        - action: structured_metadata
-          regex: ".*" # 全ての属性をキャッチ
 
 table_manager:
   retention_deletes_enabled: true

--- a/infra/otel/config.yaml
+++ b/infra/otel/config.yaml
@@ -5,12 +5,6 @@ receivers:
         endpoint: "0.0.0.0:4317"
       http:
         endpoint: "0.0.0.0:4318"
-        cors:
-          allowed_origins:
-            - "http://localhost:*"
-            - "http://backend-api:*"
-            - "http://customer:*"
-            - "http://admin:*"
 
 processors:
   # バッチ処理でパフォーマンス最適化
@@ -19,43 +13,21 @@ processors:
     send_batch_size: 1024
     send_batch_max_size: 2048
 
-  # 環境情報を追加
-  attributes/add_env:
-    actions:
-      - key: environment
-        value: "development"
-        action: insert
-      - key: deployment.environment
-        value: "development"
-        action: insert
-
   # メモリ制限
   memory_limiter:
     limit_mib: 200
     spike_limit_mib: 50
     check_interval: 5s
 
-  # リソース情報の変換
-  resource:
-    attributes:
-      - key: service.name
-        from_attribute: service_name
-        action: upsert
-      - key: service.version
-        from_attribute: service_version
-        action: upsert
-
 exporters:
   debug/stdout:
     verbosity: normal
-    sampling_initial: 5
-    sampling_thereafter: 200
   otlphttp/loki:
     endpoint: http://loki:3100/otlp
   otlphttp/mimir:
     endpoint: http://mimir:9009/otlp
   otlp/tempo:
-    endpoint: "tempo:4317"
+    endpoint: http://tempo:4317
     tls:
       insecure: true
 
@@ -73,21 +45,22 @@ service:
   pipelines:
     logs:
       receivers: [otlp]
-      processors: [memory_limiter, attributes/add_env, resource, batch]
+      processors: [memory_limiter, batch]
       exporters: [otlphttp/loki]
 
     metrics:
       receivers: [otlp]
-      processors: [memory_limiter, attributes/add_env, resource, batch]
+      processors: [memory_limiter, batch]
       exporters: [debug/stdout, otlphttp/mimir]
 
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, attributes/add_env, resource, batch]
+      processors: [memory_limiter, batch]
       exporters: [otlp/tempo]
 
   telemetry:
     logs:
+      level: "debug"
       processors:
         - batch:
             exporter:

--- a/infra/prometheus/config.yaml
+++ b/infra/prometheus/config.yaml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: "prometheus"
+    static_configs:
+      - targets: ["localhost:9090"]


### PR DESCRIPTION
## 概要

OpenTelemetryのスパン管理をより効率的かつ保守性の高いコードに改善し、併せてインフラ設定の最適化を実施しました。

**関連Issue:** #52

## 変更内容

### OpenTelemetryリファクタリング
- `WithSpan`と`WithSpanValue`ヘルパー関数を新規追加（`span_helper.go`）
- Functional Optionパターンによる`Start`関数の改善（`WithSkip`、`WithAttributes`オプション追加）
- 全ハンドラー、ユースケース、リーダーで統一されたスパン管理パターンに移行
- 手動でのスパン開始・終了処理から自動管理への変更

### インフラ設定最適化
- 不要なAlloyサービスの削除
- Lokiの冗長な構造化メタデータ設定の除去
- データベース接続設定にOpenTelemetry属性を追加
- compose.ymlの依存関係とサービス設定の改善

### 主な技術的改善点
- エラーハンドリングの統一化
- コンテキストの適切な伝播
- コードの可読性と保守性の向上
- SQLクエリトレーシングの最適化

## 確認事項

- [x] 既存APIの互換性確認
- [x] OpenTelemetryトレース機能の動作確認
- [x] 古いスパン管理パターンの完全除去
- [x] エラーハンドリングの統一性確認
- [x] インフラ設定の妥当性確認

## 変更統計

- **23ファイル変更** (673行追加、492行削除)
- **主要変更箇所**: OpenTelemetryパッケージ、各種ハンドラー、インフラ設定

## コミット履歴

- alloyを削除。lokiの不要な設定を削除
- compose.ymlの設定を更新し、otel-collectorの依存関係をservice_startedに変更。PrometheusとAlloyのサービスを追加し、Grafanaの設定を見直し。Taskfile.ymlでのクリーンアップコマンドをスキップに変更し、MySQLの起動確認を追加。新しい設定ファイルを追加し、LokiとTempoの設定を強化。
- データベース接続設定にOpenTelemetryの属性を追加し、SQLクエリの記録オプションを明示化。接続エラー時のログ出力を改善。
- Start関数にFunctional Optionパターンを導入し、スキップレベルと属性をオプションとして設定可能に変更。WithSpanおよびWithSpanValueでの呼び出しを更新。
- WithSpan, WithSpanValueを使って書き換え

## 残タスク（もしあれば）

- OpenTelemetryの新機能に対するユニットテスト追加
- 使用方法ドキュメントの整備

## その他特記事項

この変更により、OpenTelemetryの使用パターンが大幅に簡潔化され、今後の開発における一貫性が向上します。破壊的変更はなく、既存の機能はすべて保持されています。